### PR TITLE
Migrate from Zod to Valibot for validation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+# Pull Request
+
+## Description
+**What changed and why?** (Be concise)
+
+## Type
+- [ ] Feature
+- [ ] Bug Fix
+- [ ] Refactor
+- [ ] Docs
+- [ ] Chore
+
+## Impact Level
+- [ ] Low
+- [ ] Medium
+- [ ] High
+
+## Breaking Changes
+**If applicable:** Describe what breaks and migration path
+
+## Testing Checklist
+- [ ] Tested locally
+- [ ] No new console errors
+- [ ] No accessibility regressions
+- [ ] Vitest passing (if applicable)
+
+## Stack-Specific Notes
+**If applicable:** Sentry instrumentation? New shadcn component? Route changes? Dep version updates?
+
+## Deployment Notes
+**If applicable:** Any env vars, config changes, or deployment considerations?

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
         "tailwind-merge": "^3.0.2",
         "tailwindcss": "^4.0.6",
         "tw-animate-css": "^1.3.6",
-        "vite-tsconfig-paths": "^5.1.4",
-        "zod": "^4.1.11"
+        "valibot": "^1.2.0",
+        "vite-tsconfig-paths": "^5.1.4"
       },
       "devDependencies": {
         "@tanstack/devtools-vite": "^0.3.11",
@@ -8169,6 +8169,21 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/valibot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite": {
       "version": "7.2.7",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.7.tgz",
@@ -8972,16 +8987,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
-    },
-    "node_modules/zod": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
-      "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.0.6",
     "tw-animate-css": "^1.3.6",
-    "vite-tsconfig-paths": "^5.1.4",
-    "zod": "^4.1.11"
+    "valibot": "^1.2.0",
+    "vite-tsconfig-paths": "^5.1.4"
   },
   "devDependencies": {
     "@tanstack/devtools-vite": "^0.3.11",

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,19 +1,19 @@
-import { createEnv } from '@t3-oss/env-core'
-import { z } from 'zod'
+import { createEnv } from "@t3-oss/env-core";
+import * as v from "valibot";
 
 export const env = createEnv({
   server: {
-    SERVER_URL: z.string().url().optional(),
+    SERVER_URL: v.optional(v.pipe(v.string(), v.url())),
   },
 
   /**
    * The prefix that client-side variables must have. This is enforced both at
    * a type-level and at runtime.
    */
-  clientPrefix: 'VITE_',
+  clientPrefix: "VITE_",
 
   client: {
-    VITE_APP_TITLE: z.string().min(1).optional(),
+    VITE_APP_TITLE: v.optional(v.pipe(v.string(), v.minLength(1))),
   },
 
   /**
@@ -24,10 +24,10 @@ export const env = createEnv({
 
   /**
    * By default, this library will feed the environment variables directly to
-   * the Zod validator.
+   * the valibot validator.
    *
    * This means that if you have an empty string for a value that is supposed
-   * to be a number (e.g. `PORT=` in a ".env" file), Zod will incorrectly flag
+   * to be a number (e.g. `PORT=` in a ".env" file), valibot will incorrectly flag
    * it as a type mismatch violation. Additionally, if you have an empty string
    * for a value that is supposed to be a string with a default value (e.g.
    * `DOMAIN=` in an ".env" file), the default value will never be applied.
@@ -36,4 +36,4 @@ export const env = createEnv({
    * explicitly specify this option as true.
    */
   emptyStringAsUndefined: true,
-})
+});

--- a/src/routes/demo/form.simple.tsx
+++ b/src/routes/demo/form.simple.tsx
@@ -1,47 +1,47 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { z } from 'zod'
+import { createFileRoute } from "@tanstack/react-router";
+import * as v from "valibot";
 
-import { useAppForm } from '@/hooks/demo.form'
+import { useAppForm } from "@/hooks/demo.form";
 
-export const Route = createFileRoute('/demo/form/simple')({
+export const Route = createFileRoute("/demo/form/simple")({
   component: SimpleForm,
-})
+});
 
-const schema = z.object({
-  title: z.string().min(1, 'Title is required'),
-  description: z.string().min(1, 'Description is required'),
-})
+const schema = v.object({
+  title: v.pipe(v.string(), v.minLength(1, "Title is required")),
+  description: v.pipe(v.string(), v.minLength(1, "Description is required")),
+});
 
 function SimpleForm() {
   const form = useAppForm({
     defaultValues: {
-      title: '',
-      description: '',
+      title: "",
+      description: "",
     },
     validators: {
       onBlur: schema,
     },
     onSubmit: ({ value }) => {
-      console.log(value)
+      console.log(value);
       // Show success message
-      alert('Form submitted successfully!')
+      alert("Form submitted successfully!");
     },
-  })
+  });
 
   return (
     <div
       className="flex items-center justify-center min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 p-4 text-white"
       style={{
         backgroundImage:
-          'radial-gradient(50% 50% at 5% 40%, #add8e6 0%, #0000ff 70%, #00008b 100%)',
+          "radial-gradient(50% 50% at 5% 40%, #add8e6 0%, #0000ff 70%, #00008b 100%)",
       }}
     >
       <div className="w-full max-w-2xl p-8 rounded-xl backdrop-blur-md bg-black/50 shadow-xl border-8 border-black/10">
         <form
           onSubmit={(e) => {
-            e.preventDefault()
-            e.stopPropagation()
-            form.handleSubmit()
+            e.preventDefault();
+            e.stopPropagation();
+            form.handleSubmit();
           }}
           className="space-y-6"
         >
@@ -61,5 +61,5 @@ function SimpleForm() {
         </form>
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
# Pull Request

## Description
**Migrated validation library from Zod to Valibot** for more lightweight, tree-shakeable validation with better performance. #9

## Type
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Docs
- [ ] Chore

## Impact Level
- [ ] Low
- [x] Medium
- [ ] High

## Breaking Changes
Zod has been removed from dependencies. Validation schemas now use Valibot API instead. No breaking changes to external API - this is internal refactoring only.

## Testing Checklist
- [x] Tested locally
- [x] No new console errors
- [x] No accessibility regressions
- [x] Vitest passing (if applicable)

## Stack-Specific Notes
Updated `src/env.ts` to use Valibot's schema validation. Updated form component in `src/routes/demo/form.simple.tsx` to use Valibot validation API instead of Zod.

## Deployment Notes
No environment variables or config changes required.